### PR TITLE
fix: Include shaders from classpath on gwt

### DIFF
--- a/lib/src/main/resources/com/maltaisn/msdf-gdx.gwt.xml
+++ b/lib/src/main/resources/com/maltaisn/msdf-gdx.gwt.xml
@@ -3,4 +3,7 @@
         "http://www.gwtproject.org/doctype/2.8.2/gwt-module.dtd">
 <module>
     <source path="msdfgdx" />
+
+    <extend-configuration-property name="gdx.files.classpath" value="font.frag" />
+    <extend-configuration-property name="gdx.files.classpath" value="font.vert" />
 </module>


### PR DESCRIPTION
libgdx/libgdx@62a8ca93316e2d4656664838ff705e26c0433a34
fixes #5 (I think)